### PR TITLE
Made panics abort on the "release" profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # TBD
+### `nstd`
+- The overflow behavior for the "release" profile has been set to panic.
+- The panic behavior for the "release" profile has been set to abort.
 ### `nstd.core`
 - Made `math_[clamp|div_ceil|div_floor]_*` safe.
 ### `nstd.os`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # TBD
+### `nstd.core`
+- Made `math_[clamp|div_ceil|div_floor]_*` safe.
 ### `nstd.os`
 - Added `NSTDWindowsAllocError`.
 - Renamed `NSTDWindowsHeapHandle` to `NSTDWindowsHeap`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ exclude = ["include"]
 all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
 
+[profile.release]
+overflow-checks = true
+panic = "abort"
+
 [lib]
 crate-type = ["cdylib", "rlib", "staticlib"]
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ can easily use the API.
 
 - Any operation that makes a direct call on a C function pointer is considered unsafe.
 
-- Any function that may panic must be marked as unsafe, as it is undefined behavior to unwind from
-Rust code into foreign code (though this is
+- The panic behavior is set to abort by default, as it is undefined behavior to unwind from Rust
+code into foreign code (though this is
 [subject to change](https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html)).
 
 - Reference arguments are assumed to be valid (aligned, non-null, and non-dangling), and are safe

--- a/include/nstd/alloc.h
+++ b/include/nstd/alloc.h
@@ -35,8 +35,6 @@ typedef enum {
 ///
 /// - The new memory buffer should be considered uninitialized.
 ///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
@@ -66,9 +64,7 @@ NSTDAPI NSTDAnyMut nstd_alloc_allocate(NSTDUInt size);
 ///
 /// # Safety
 ///
-/// - Behavior is undefined if `size` is zero.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// Behavior is undefined if `size` is zero.
 ///
 /// # Example
 ///
@@ -117,8 +113,6 @@ NSTDAPI NSTDAnyMut nstd_alloc_allocate_zeroed(NSTDUInt size);
 ///
 /// - `size` must be the same value that was used to allocate the memory buffer.
 ///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
@@ -159,8 +153,6 @@ NSTDAPI NSTDAllocError nstd_alloc_reallocate(NSTDAnyMut *ptr, NSTDUInt size, NST
 /// - Behavior is undefined if `ptr` is not a value returned by `nstd_alloc_allocate[_zeroed]`.
 ///
 /// - `size` must be the same value that was used to allocate the memory buffer.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
 ///
 /// # Example
 ///

--- a/include/nstd/core/cstr/cstr.h
+++ b/include/nstd/core/cstr/cstr.h
@@ -150,9 +150,7 @@ NSTDAPI NSTDUInt nstd_core_cstr_len(const NSTDCStr *cstr);
 ///
 /// # Safety
 ///
-/// - Undefined behavior may occur if `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// Undefined behavior may occur if `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -419,9 +417,7 @@ NSTDAPI NSTDUInt nstd_core_cstr_mut_len(const NSTDCStrMut *cstr);
 ///
 /// # Safety
 ///
-/// - Undefined behavior may occur if `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// Undefined behavior may occur if `cstr`'s data is invalid.
 ///
 /// # Example
 ///

--- a/include/nstd/core/cty.h
+++ b/include/nstd/core/cty.h
@@ -180,7 +180,6 @@ NSTDAPI NSTDBool nstd_core_cty_is_control(NSTDUnichar chr);
 /// assert!(nstd_core_cty_is_digit('5'.into(), 16) != 0);
 /// assert!(nstd_core_cty_is_digit('E'.into(), 16) != 0);
 /// assert!(nstd_core_cty_is_digit('F'.into(), 10) == 0);
-/// assert!(nstd_core_cty_is_digit('9'.into(), 37) == 0);
 /// ```
 NSTDAPI NSTDBool nstd_core_cty_is_digit(NSTDUnichar chr, NSTDUInt32 radix);
 

--- a/include/nstd/core/cty.h
+++ b/include/nstd/core/cty.h
@@ -168,6 +168,10 @@ NSTDAPI NSTDBool nstd_core_cty_is_control(NSTDUnichar chr);
 ///
 /// `NSTDBool is_digit` - `NSTD_TRUE` if `chr` is a digit.
 ///
+/// # Panics
+///
+/// This function will panic if `radix` is greater than 36.
+///
 /// # Example
 ///
 /// ```

--- a/include/nstd/core/math.h
+++ b/include/nstd/core/math.h
@@ -354,20 +354,14 @@ NSTDAPI NSTDUInt64 nstd_core_math_pow_u64(NSTDUInt64 x, NSTDUInt32 exp);
 ///
 /// Panics if `min` > `max`, `min` is NaN, or `max` is NaN.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_f32;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_f32(2.5, 3.0, 5.0) == 3.0);
-///     assert!(nstd_core_math_clamp_f32(4.0, 3.0, 5.0) == 4.0);
-///     assert!(nstd_core_math_clamp_f32(7.5, 3.0, 5.0) == 5.0);
-/// }
+/// assert!(nstd_core_math_clamp_f32(2.5, 3.0, 5.0) == 3.0);
+/// assert!(nstd_core_math_clamp_f32(4.0, 3.0, 5.0) == 4.0);
+/// assert!(nstd_core_math_clamp_f32(7.5, 3.0, 5.0) == 5.0);
 /// ```
 NSTDAPI NSTDFloat32 nstd_core_math_clamp_f32(NSTDFloat32 x, NSTDFloat32 min, NSTDFloat32 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -388,20 +382,14 @@ NSTDAPI NSTDFloat32 nstd_core_math_clamp_f32(NSTDFloat32 x, NSTDFloat32 min, NST
 ///
 /// Panics if `min` > `max`, `min` is NaN, or `max` is NaN.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_f64;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_f64(2.5, 3.0, 5.0) == 3.0);
-///     assert!(nstd_core_math_clamp_f64(4.0, 3.0, 5.0) == 4.0);
-///     assert!(nstd_core_math_clamp_f64(7.5, 3.0, 5.0) == 5.0);
-/// }
+/// assert!(nstd_core_math_clamp_f64(2.5, 3.0, 5.0) == 3.0);
+/// assert!(nstd_core_math_clamp_f64(4.0, 3.0, 5.0) == 4.0);
+/// assert!(nstd_core_math_clamp_f64(7.5, 3.0, 5.0) == 5.0);
 /// ```
 NSTDAPI NSTDFloat64 nstd_core_math_clamp_f64(NSTDFloat64 x, NSTDFloat64 min, NSTDFloat64 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -422,20 +410,14 @@ NSTDAPI NSTDFloat64 nstd_core_math_clamp_f64(NSTDFloat64 x, NSTDFloat64 min, NST
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_int;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_int(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_int(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_int(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_int(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_int(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_int(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDInt nstd_core_math_clamp_int(NSTDInt x, NSTDInt min, NSTDInt max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -456,20 +438,14 @@ NSTDAPI NSTDInt nstd_core_math_clamp_int(NSTDInt x, NSTDInt min, NSTDInt max);
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_uint;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_uint(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_uint(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_uint(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_uint(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_uint(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_uint(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDUInt nstd_core_math_clamp_uint(NSTDUInt x, NSTDUInt min, NSTDUInt max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -490,20 +466,14 @@ NSTDAPI NSTDUInt nstd_core_math_clamp_uint(NSTDUInt x, NSTDUInt min, NSTDUInt ma
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_i8;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_i8(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_i8(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_i8(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_i8(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_i8(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_i8(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDInt8 nstd_core_math_clamp_i8(NSTDInt8 x, NSTDInt8 min, NSTDInt8 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -524,20 +494,14 @@ NSTDAPI NSTDInt8 nstd_core_math_clamp_i8(NSTDInt8 x, NSTDInt8 min, NSTDInt8 max)
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_u8;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_u8(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_u8(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_u8(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_u8(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_u8(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_u8(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDUInt8 nstd_core_math_clamp_u8(NSTDUInt8 x, NSTDUInt8 min, NSTDUInt8 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -558,20 +522,14 @@ NSTDAPI NSTDUInt8 nstd_core_math_clamp_u8(NSTDUInt8 x, NSTDUInt8 min, NSTDUInt8 
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_i16;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_i16(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_i16(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_i16(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_i16(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_i16(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_i16(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDInt16 nstd_core_math_clamp_i16(NSTDInt16 x, NSTDInt16 min, NSTDInt16 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -592,20 +550,14 @@ NSTDAPI NSTDInt16 nstd_core_math_clamp_i16(NSTDInt16 x, NSTDInt16 min, NSTDInt16
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_u16;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_u16(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_u16(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_u16(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_u16(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_u16(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_u16(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDUInt16 nstd_core_math_clamp_u16(NSTDUInt16 x, NSTDUInt16 min, NSTDUInt16 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -626,20 +578,14 @@ NSTDAPI NSTDUInt16 nstd_core_math_clamp_u16(NSTDUInt16 x, NSTDUInt16 min, NSTDUI
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_i32;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_i32(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_i32(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_i32(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_i32(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_i32(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_i32(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDInt32 nstd_core_math_clamp_i32(NSTDInt32 x, NSTDInt32 min, NSTDInt32 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -660,20 +606,14 @@ NSTDAPI NSTDInt32 nstd_core_math_clamp_i32(NSTDInt32 x, NSTDInt32 min, NSTDInt32
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_u32;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_u32(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_u32(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_u32(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_u32(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_u32(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_u32(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDUInt32 nstd_core_math_clamp_u32(NSTDUInt32 x, NSTDUInt32 min, NSTDUInt32 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -694,20 +634,14 @@ NSTDAPI NSTDUInt32 nstd_core_math_clamp_u32(NSTDUInt32 x, NSTDUInt32 min, NSTDUI
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_i64;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_i64(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_i64(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_i64(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_i64(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_i64(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_i64(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDInt64 nstd_core_math_clamp_i64(NSTDInt64 x, NSTDInt64 min, NSTDInt64 max);
 /// Clamps the value `x` to the bounds `min` and `max`.
@@ -728,20 +662,14 @@ NSTDAPI NSTDInt64 nstd_core_math_clamp_i64(NSTDInt64 x, NSTDInt64 min, NSTDInt64
 ///
 /// Panics if `min` > `max`.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_clamp_u64;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_clamp_u64(2, 5, 10) == 5);
-///     assert!(nstd_core_math_clamp_u64(8, 5, 10) == 8);
-///     assert!(nstd_core_math_clamp_u64(14, 5, 10) == 10);
-/// }
+/// assert!(nstd_core_math_clamp_u64(2, 5, 10) == 5);
+/// assert!(nstd_core_math_clamp_u64(8, 5, 10) == 8);
+/// assert!(nstd_core_math_clamp_u64(14, 5, 10) == 10);
 /// ```
 NSTDAPI NSTDUInt64 nstd_core_math_clamp_u64(NSTDUInt64 x, NSTDUInt64 min, NSTDUInt64 max);
 
@@ -761,20 +689,14 @@ NSTDAPI NSTDUInt64 nstd_core_math_clamp_u64(NSTDUInt64 x, NSTDUInt64 min, NSTDUI
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_int;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_int(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_int(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_int(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_int(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_int(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_int(8, 2) == 4);
 /// ```
 NSTDAPI NSTDInt nstd_core_math_div_ceil_int(NSTDInt x, NSTDInt y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -793,20 +715,14 @@ NSTDAPI NSTDInt nstd_core_math_div_ceil_int(NSTDInt x, NSTDInt y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_uint;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_uint(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_uint(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_uint(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_uint(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_uint(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_uint(8, 2) == 4);
 /// ```
 NSTDAPI NSTDUInt nstd_core_math_div_ceil_uint(NSTDUInt x, NSTDUInt y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -825,20 +741,14 @@ NSTDAPI NSTDUInt nstd_core_math_div_ceil_uint(NSTDUInt x, NSTDUInt y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_i8;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_i8(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_i8(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_i8(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_i8(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_i8(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_i8(8, 2) == 4);
 /// ```
 NSTDAPI NSTDInt8 nstd_core_math_div_ceil_i8(NSTDInt8 x, NSTDInt8 y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -857,20 +767,14 @@ NSTDAPI NSTDInt8 nstd_core_math_div_ceil_i8(NSTDInt8 x, NSTDInt8 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_u8;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_u8(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_u8(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_u8(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_u8(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_u8(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_u8(8, 2) == 4);
 /// ```
 NSTDAPI NSTDUInt8 nstd_core_math_div_ceil_u8(NSTDUInt8 x, NSTDUInt8 y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -889,20 +793,14 @@ NSTDAPI NSTDUInt8 nstd_core_math_div_ceil_u8(NSTDUInt8 x, NSTDUInt8 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_i16;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_i16(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_i16(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_i16(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_i16(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_i16(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_i16(8, 2) == 4);
 /// ```
 NSTDAPI NSTDInt16 nstd_core_math_div_ceil_i16(NSTDInt16 x, NSTDInt16 y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -921,20 +819,14 @@ NSTDAPI NSTDInt16 nstd_core_math_div_ceil_i16(NSTDInt16 x, NSTDInt16 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_u16;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_u16(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_u16(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_u16(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_u16(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_u16(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_u16(8, 2) == 4);
 /// ```
 NSTDAPI NSTDUInt16 nstd_core_math_div_ceil_u16(NSTDUInt16 x, NSTDUInt16 y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -953,20 +845,14 @@ NSTDAPI NSTDUInt16 nstd_core_math_div_ceil_u16(NSTDUInt16 x, NSTDUInt16 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_i32;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_i32(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_i32(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_i32(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_i32(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_i32(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_i32(8, 2) == 4);
 /// ```
 NSTDAPI NSTDInt32 nstd_core_math_div_ceil_i32(NSTDInt32 x, NSTDInt32 y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -985,20 +871,14 @@ NSTDAPI NSTDInt32 nstd_core_math_div_ceil_i32(NSTDInt32 x, NSTDInt32 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_u32;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_u32(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_u32(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_u32(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_u32(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_u32(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_u32(8, 2) == 4);
 /// ```
 NSTDAPI NSTDUInt32 nstd_core_math_div_ceil_u32(NSTDUInt32 x, NSTDUInt32 y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -1017,20 +897,14 @@ NSTDAPI NSTDUInt32 nstd_core_math_div_ceil_u32(NSTDUInt32 x, NSTDUInt32 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_i64;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_i64(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_i64(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_i64(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_i64(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_i64(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_i64(8, 2) == 4);
 /// ```
 NSTDAPI NSTDInt64 nstd_core_math_div_ceil_i64(NSTDInt64 x, NSTDInt64 y);
 /// Divides two numbers and rounds the result up to the next integer.
@@ -1049,20 +923,14 @@ NSTDAPI NSTDInt64 nstd_core_math_div_ceil_i64(NSTDInt64 x, NSTDInt64 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_ceil_u64;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_ceil_u64(8, 5) == 2);
-///     assert!(nstd_core_math_div_ceil_u64(8, 3) == 3);
-///     assert!(nstd_core_math_div_ceil_u64(8, 2) == 4);
-/// }
+/// assert!(nstd_core_math_div_ceil_u64(8, 5) == 2);
+/// assert!(nstd_core_math_div_ceil_u64(8, 3) == 3);
+/// assert!(nstd_core_math_div_ceil_u64(8, 2) == 4);
 /// ```
 NSTDAPI NSTDUInt64 nstd_core_math_div_ceil_u64(NSTDUInt64 x, NSTDUInt64 y);
 
@@ -1082,20 +950,14 @@ NSTDAPI NSTDUInt64 nstd_core_math_div_ceil_u64(NSTDUInt64 x, NSTDUInt64 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_int;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_int(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_int(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_int(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_int(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_int(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_int(23, 5) == 4);
 /// ```
 NSTDAPI NSTDInt nstd_core_math_div_floor_int(NSTDInt x, NSTDInt y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1114,20 +976,14 @@ NSTDAPI NSTDInt nstd_core_math_div_floor_int(NSTDInt x, NSTDInt y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_uint;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_uint(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_uint(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_uint(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_uint(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_uint(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_uint(23, 5) == 4);
 /// ```
 NSTDAPI NSTDUInt nstd_core_math_div_floor_uint(NSTDUInt x, NSTDUInt y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1146,20 +1002,14 @@ NSTDAPI NSTDUInt nstd_core_math_div_floor_uint(NSTDUInt x, NSTDUInt y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_i8;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_i8(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_i8(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_i8(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_i8(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_i8(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_i8(23, 5) == 4);
 /// ```
 NSTDAPI NSTDInt8 nstd_core_math_div_floor_i8(NSTDInt8 x, NSTDInt8 y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1178,20 +1028,14 @@ NSTDAPI NSTDInt8 nstd_core_math_div_floor_i8(NSTDInt8 x, NSTDInt8 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_u8;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_u8(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_u8(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_u8(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_u8(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_u8(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_u8(23, 5) == 4);
 /// ```
 NSTDAPI NSTDUInt8 nstd_core_math_div_floor_u8(NSTDUInt8 x, NSTDUInt8 y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1210,20 +1054,14 @@ NSTDAPI NSTDUInt8 nstd_core_math_div_floor_u8(NSTDUInt8 x, NSTDUInt8 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_i16;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_i16(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_i16(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_i16(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_i16(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_i16(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_i16(23, 5) == 4);
 /// ```
 NSTDAPI NSTDInt16 nstd_core_math_div_floor_i16(NSTDInt16 x, NSTDInt16 y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1242,20 +1080,14 @@ NSTDAPI NSTDInt16 nstd_core_math_div_floor_i16(NSTDInt16 x, NSTDInt16 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_u16;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_u16(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_u16(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_u16(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_u16(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_u16(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_u16(23, 5) == 4);
 /// ```
 NSTDAPI NSTDUInt16 nstd_core_math_div_floor_u16(NSTDUInt16 x, NSTDUInt16 y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1274,20 +1106,14 @@ NSTDAPI NSTDUInt16 nstd_core_math_div_floor_u16(NSTDUInt16 x, NSTDUInt16 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_i32;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_i32(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_i32(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_i32(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_i32(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_i32(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_i32(23, 5) == 4);
 /// ```
 NSTDAPI NSTDInt32 nstd_core_math_div_floor_i32(NSTDInt32 x, NSTDInt32 y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1306,20 +1132,14 @@ NSTDAPI NSTDInt32 nstd_core_math_div_floor_i32(NSTDInt32 x, NSTDInt32 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_u32;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_u32(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_u32(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_u32(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_u32(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_u32(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_u32(23, 5) == 4);
 /// ```
 NSTDAPI NSTDUInt32 nstd_core_math_div_floor_u32(NSTDUInt32 x, NSTDUInt32 y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1338,20 +1158,14 @@ NSTDAPI NSTDUInt32 nstd_core_math_div_floor_u32(NSTDUInt32 x, NSTDUInt32 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_i64;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_i64(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_i64(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_i64(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_i64(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_i64(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_i64(23, 5) == 4);
 /// ```
 NSTDAPI NSTDInt64 nstd_core_math_div_floor_i64(NSTDInt64 x, NSTDInt64 y);
 /// Divides two numbers and rounds the result down to the next integer.
@@ -1370,20 +1184,14 @@ NSTDAPI NSTDInt64 nstd_core_math_div_floor_i64(NSTDInt64 x, NSTDInt64 y);
 ///
 /// This operation will panic if `y` is 0.
 ///
-/// # Safety
-///
-/// This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
 /// use nstd_sys::core::math::nstd_core_math_div_floor_u64;
 ///
-/// unsafe {
-///     assert!(nstd_core_math_div_floor_u64(5, 2) == 2);
-///     assert!(nstd_core_math_div_floor_u64(13, 4) == 3);
-///     assert!(nstd_core_math_div_floor_u64(23, 5) == 4);
-/// }
+/// assert!(nstd_core_math_div_floor_u64(5, 2) == 2);
+/// assert!(nstd_core_math_div_floor_u64(13, 4) == 3);
+/// assert!(nstd_core_math_div_floor_u64(23, 5) == 4);
 /// ```
 NSTDAPI NSTDUInt64 nstd_core_math_div_floor_u64(NSTDUInt64 x, NSTDUInt64 y);
 

--- a/include/nstd/core/str.h
+++ b/include/nstd/core/str.h
@@ -34,9 +34,7 @@ typedef struct {
 ///
 /// # Safety
 ///
-/// - `cstr`'s data must be valid for reads of at least `cstr.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// `cstr`'s data must be valid for reads of at least `cstr.len` consecutive bytes.
 ///
 /// # Example
 ///
@@ -107,10 +105,8 @@ NSTDAPI NSTDStr nstd_core_str_from_cstr_unchecked(const NSTDCStr *cstr);
 ///
 /// # Safety
 ///
-/// - This function makes access to raw pointer data, which can cause undefined behavior in the
-/// event that `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This function makes access to raw pointer data, which can cause undefined behavior in the event
+/// that `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -145,10 +141,8 @@ NSTDAPI NSTDStr nstd_core_str_from_raw_cstr(const NSTDChar *cstr);
 ///
 /// # Safety
 ///
-/// - This function makes access to raw pointer data, which can cause undefined behavior in the
-/// event that `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This function makes access to raw pointer data, which can cause undefined behavior in the event
+/// that `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -189,8 +183,6 @@ NSTDAPI NSTDStr nstd_core_str_from_raw_cstr_with_null(const NSTDChar *cstr);
 ///
 /// - `bytes`'s data must be valid for reads of at least `bytes.len` consecutive bytes.
 ///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
@@ -229,8 +221,6 @@ NSTDAPI NSTDStr nstd_core_str_from_bytes(const NSTDSlice *bytes);
 /// - `bytes` must remain valid while the returned string slice is in use.
 ///
 /// - `bytes`'s data must be valid for reads of at least `bytes.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
 ///
 /// # Example
 ///
@@ -304,9 +294,7 @@ NSTDAPI const NSTDByte *nstd_core_str_as_ptr(const NSTDStr *str);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -368,9 +356,7 @@ NSTDAPI NSTDUInt nstd_core_str_byte_len(const NSTDStr *str);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -413,9 +399,7 @@ NSTDAPI NSTDUnichar nstd_core_str_get_char(const NSTDStr *str, NSTDUInt pos);
 ///
 /// # Safety
 ///
-/// - `str`'s data must be valid for reads of at least `str.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// `str`'s data must be valid for reads of at least `str.len` consecutive bytes.
 ///
 /// # Example
 ///
@@ -457,10 +441,7 @@ NSTDAPI NSTDStr nstd_core_str_substr(const NSTDStr *str, NSTDURange range);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -495,10 +476,7 @@ NSTDAPI NSTDFloat32 nstd_core_str_to_f32(const NSTDStr *str, NSTDErrorCode *errc
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -533,10 +511,7 @@ NSTDAPI NSTDFloat64 nstd_core_str_to_f64(const NSTDStr *str, NSTDErrorCode *errc
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -571,10 +546,7 @@ NSTDAPI NSTDInt nstd_core_str_to_int(const NSTDStr *str, NSTDErrorCode *errc);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -609,10 +581,7 @@ NSTDAPI NSTDUInt nstd_core_str_to_uint(const NSTDStr *str, NSTDErrorCode *errc);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -647,10 +616,7 @@ NSTDAPI NSTDInt8 nstd_core_str_to_i8(const NSTDStr *str, NSTDErrorCode *errc);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -685,10 +651,7 @@ NSTDAPI NSTDUInt8 nstd_core_str_to_u8(const NSTDStr *str, NSTDErrorCode *errc);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -723,10 +686,7 @@ NSTDAPI NSTDInt16 nstd_core_str_to_i16(const NSTDStr *str, NSTDErrorCode *errc);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -761,10 +721,7 @@ NSTDAPI NSTDUInt16 nstd_core_str_to_u16(const NSTDStr *str, NSTDErrorCode *errc)
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -799,10 +756,7 @@ NSTDAPI NSTDInt32 nstd_core_str_to_i32(const NSTDStr *str, NSTDErrorCode *errc);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -837,10 +791,7 @@ NSTDAPI NSTDUInt32 nstd_core_str_to_u32(const NSTDStr *str, NSTDErrorCode *errc)
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -875,10 +826,7 @@ NSTDAPI NSTDInt64 nstd_core_str_to_i64(const NSTDStr *str, NSTDErrorCode *errc);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -923,9 +871,7 @@ typedef struct {
 ///
 /// # Safety
 ///
-/// - `cstr`'s data must be valid for reads of at least `cstr.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// `cstr`'s data must be valid for reads of at least `cstr.len` consecutive bytes.
 ///
 /// # Example
 ///
@@ -996,10 +942,8 @@ NSTDAPI NSTDStrMut nstd_core_str_mut_from_cstr_unchecked(NSTDCStrMut *cstr);
 ///
 /// # Safety
 ///
-/// - This function makes access to raw pointer data, which can cause undefined behavior in the
-/// event that `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This function makes access to raw pointer data, which can cause undefined behavior in the event
+/// that `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1034,10 +978,8 @@ NSTDAPI NSTDStrMut nstd_core_str_mut_from_raw_cstr(NSTDChar *cstr);
 ///
 /// # Safety
 ///
-/// - This function makes access to raw pointer data, which can cause undefined behavior in the
-/// event that `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This function makes access to raw pointer data, which can cause undefined behavior in the event
+/// that `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1080,8 +1022,6 @@ NSTDAPI NSTDStrMut nstd_core_str_mut_from_raw_cstr_with_null(NSTDChar *cstr);
 ///
 /// - `bytes`'s data must be valid for reads of at least `bytes.len` consecutive bytes.
 ///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
@@ -1120,8 +1060,6 @@ NSTDAPI NSTDStrMut nstd_core_str_mut_from_bytes(NSTDSliceMut *bytes);
 /// - `bytes` must remain valid while the returned string slice is in use.
 ///
 /// - `bytes`'s data must be valid for reads of at least `bytes.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
 ///
 /// # Example
 ///
@@ -1208,9 +1146,7 @@ NSTDAPI const NSTDByte *nstd_core_str_mut_as_ptr(const NSTDStrMut *str);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1274,9 +1210,7 @@ NSTDAPI NSTDUInt nstd_core_str_mut_byte_len(const NSTDStrMut *str);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1319,9 +1253,7 @@ NSTDAPI NSTDUnichar nstd_core_str_mut_get_char(const NSTDStrMut *str, NSTDUInt p
 ///
 /// # Safety
 ///
-/// - `str`'s data must be valid for reads of at least `str.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// `str`'s data must be valid for reads of at least `str.len` consecutive bytes.
 ///
 /// # Example
 ///
@@ -1365,10 +1297,7 @@ NSTDAPI NSTDStrMut nstd_core_str_mut_substr(NSTDStrMut *str, NSTDURange range);
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1403,10 +1332,7 @@ NSTDAPI NSTDFloat32 nstd_core_str_mut_to_f32(const NSTDStrMut *str, NSTDErrorCod
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1441,10 +1367,7 @@ NSTDAPI NSTDFloat64 nstd_core_str_mut_to_f64(const NSTDStrMut *str, NSTDErrorCod
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1479,10 +1402,7 @@ NSTDAPI NSTDInt nstd_core_str_mut_to_int(const NSTDStrMut *str, NSTDErrorCode *e
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1517,10 +1437,7 @@ NSTDAPI NSTDUInt nstd_core_str_mut_to_uint(const NSTDStrMut *str, NSTDErrorCode 
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1555,10 +1472,7 @@ NSTDAPI NSTDInt8 nstd_core_str_mut_to_i8(const NSTDStrMut *str, NSTDErrorCode *e
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1593,10 +1507,7 @@ NSTDAPI NSTDUInt8 nstd_core_str_mut_to_u8(const NSTDStrMut *str, NSTDErrorCode *
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1631,10 +1542,7 @@ NSTDAPI NSTDInt16 nstd_core_str_mut_to_i16(const NSTDStrMut *str, NSTDErrorCode 
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1669,10 +1577,7 @@ NSTDAPI NSTDUInt16 nstd_core_str_mut_to_u16(const NSTDStrMut *str, NSTDErrorCode
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1707,10 +1612,7 @@ NSTDAPI NSTDInt32 nstd_core_str_mut_to_i32(const NSTDStrMut *str, NSTDErrorCode 
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1745,10 +1647,7 @@ NSTDAPI NSTDUInt32 nstd_core_str_mut_to_u32(const NSTDStrMut *str, NSTDErrorCode
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1783,10 +1682,7 @@ NSTDAPI NSTDInt64 nstd_core_str_mut_to_i64(const NSTDStrMut *str, NSTDErrorCode 
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is
-/// invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -57,8 +57,6 @@ impl NSTDAllocError {
 ///
 /// - The new memory buffer should be considered uninitialized.
 ///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
@@ -101,9 +99,7 @@ pub unsafe extern "C" fn nstd_alloc_allocate(size: NSTDUInt) -> NSTDAnyMut {
 ///
 /// # Safety
 ///
-/// - Behavior is undefined if `size` is zero.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// Behavior is undefined if `size` is zero.
 ///
 /// # Example
 ///
@@ -164,8 +160,6 @@ pub unsafe extern "C" fn nstd_alloc_allocate_zeroed(size: NSTDUInt) -> NSTDAnyMu
 /// - Behavior is undefined if `ptr` is not a value returned by `nstd_alloc_allocate[_zeroed]`.
 ///
 /// - `size` must be the same value that was used to allocate the memory buffer.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
 ///
 /// # Example
 ///
@@ -230,8 +224,6 @@ pub unsafe extern "C" fn nstd_alloc_reallocate(
 /// - Behavior is undefined if `ptr` is not a value returned by `nstd_alloc_allocate[_zeroed]`.
 ///
 /// - `size` must be the same value that was used to allocate the memory buffer.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
 ///
 /// # Example
 ///

--- a/src/core/cstr.rs
+++ b/src/core/cstr.rs
@@ -202,9 +202,7 @@ pub extern "C" fn nstd_core_cstr_len(cstr: &NSTDCStr) -> NSTDUInt {
 ///
 /// # Safety
 ///
-/// - Undefined behavior may occur if `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// Undefined behavior may occur if `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -548,9 +546,7 @@ pub extern "C" fn nstd_core_cstr_mut_len(cstr: &NSTDCStrMut) -> NSTDUInt {
 ///
 /// # Safety
 ///
-/// - Undefined behavior may occur if `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// Undefined behavior may occur if `cstr`'s data is invalid.
 ///
 /// # Example
 ///

--- a/src/core/cty.rs
+++ b/src/core/cty.rs
@@ -210,6 +210,10 @@ gen_deterministic!(
 ///
 /// `NSTDBool is_digit` - `NSTD_TRUE` if `chr` is a digit.
 ///
+/// # Panics
+///
+/// This function will panic if `radix` is greater than 36.
+///
 /// # Example
 ///
 /// ```
@@ -218,15 +222,12 @@ gen_deterministic!(
 /// assert!(nstd_core_cty_is_digit('5'.into(), 16) != 0);
 /// assert!(nstd_core_cty_is_digit('E'.into(), 16) != 0);
 /// assert!(nstd_core_cty_is_digit('F'.into(), 10) == 0);
-/// assert!(nstd_core_cty_is_digit('9'.into(), 37) == 0);
 /// ```
 #[inline]
 #[cfg_attr(feature = "clib", no_mangle)]
 pub extern "C" fn nstd_core_cty_is_digit(chr: NSTDUnichar, radix: NSTDUInt32) -> NSTDBool {
-    if radix <= 36 {
-        if let Some(chr) = char::from_u32(chr) {
-            return chr.is_digit(radix).into();
-        }
+    if let Some(chr) = char::from_u32(chr) {
+        return chr.is_digit(radix).into();
     }
     NSTD_FALSE
 }

--- a/src/core/math.rs
+++ b/src/core/math.rs
@@ -436,7 +436,7 @@ macro_rules! gen_clamp {
         $(#[$meta])*
         #[inline]
         #[cfg_attr(feature = "clib", no_mangle)]
-        pub unsafe extern "C" fn $name(x: $T, min: $T, max: $T) -> $T {
+        pub extern "C" fn $name(x: $T, min: $T, max: $T) -> $T {
             x.clamp(min, max)
         }
     };
@@ -460,20 +460,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`, `min` is NaN, or `max` is NaN.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_f32;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_f32(2.5, 3.0, 5.0) == 3.0);
-    ///     assert!(nstd_core_math_clamp_f32(4.0, 3.0, 5.0) == 4.0);
-    ///     assert!(nstd_core_math_clamp_f32(7.5, 3.0, 5.0) == 5.0);
-    /// }
+    /// assert!(nstd_core_math_clamp_f32(2.5, 3.0, 5.0) == 3.0);
+    /// assert!(nstd_core_math_clamp_f32(4.0, 3.0, 5.0) == 4.0);
+    /// assert!(nstd_core_math_clamp_f32(7.5, 3.0, 5.0) == 5.0);
     /// ```
     nstd_core_math_clamp_f32,
     NSTDFloat32
@@ -497,20 +491,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`, `min` is NaN, or `max` is NaN.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_f64;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_f64(2.5, 3.0, 5.0) == 3.0);
-    ///     assert!(nstd_core_math_clamp_f64(4.0, 3.0, 5.0) == 4.0);
-    ///     assert!(nstd_core_math_clamp_f64(7.5, 3.0, 5.0) == 5.0);
-    /// }
+    /// assert!(nstd_core_math_clamp_f64(2.5, 3.0, 5.0) == 3.0);
+    /// assert!(nstd_core_math_clamp_f64(4.0, 3.0, 5.0) == 4.0);
+    /// assert!(nstd_core_math_clamp_f64(7.5, 3.0, 5.0) == 5.0);
     /// ```
     nstd_core_math_clamp_f64,
     NSTDFloat64
@@ -534,20 +522,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_int;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_int(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_int(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_int(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_int(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_int(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_int(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_int,
     NSTDInt
@@ -571,20 +553,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_uint;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_uint(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_uint(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_uint(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_uint(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_uint(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_uint(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_uint,
     NSTDUInt
@@ -608,20 +584,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_i8;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_i8(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_i8(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_i8(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_i8(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_i8(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_i8(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_i8,
     NSTDInt8
@@ -645,20 +615,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_u8;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_u8(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_u8(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_u8(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_u8(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_u8(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_u8(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_u8,
     NSTDUInt8
@@ -682,20 +646,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_i16;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_i16(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_i16(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_i16(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_i16(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_i16(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_i16(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_i16,
     NSTDInt16
@@ -719,20 +677,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_u16;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_u16(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_u16(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_u16(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_u16(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_u16(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_u16(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_u16,
     NSTDUInt16
@@ -756,20 +708,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_i32;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_i32(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_i32(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_i32(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_i32(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_i32(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_i32(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_i32,
     NSTDInt32
@@ -793,20 +739,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_u32;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_u32(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_u32(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_u32(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_u32(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_u32(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_u32(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_u32,
     NSTDUInt32
@@ -830,20 +770,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_i64;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_i64(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_i64(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_i64(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_i64(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_i64(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_i64(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_i64,
     NSTDInt64
@@ -867,20 +801,14 @@ gen_clamp!(
     ///
     /// Panics if `min` > `max`.
     ///
-    /// # Safety
-    ///
-    /// This operation can cause undefined behavior if it panics into non-Rust code.
-    ///
     /// # Example
     ///
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_clamp_u64;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_clamp_u64(2, 5, 10) == 5);
-    ///     assert!(nstd_core_math_clamp_u64(8, 5, 10) == 8);
-    ///     assert!(nstd_core_math_clamp_u64(14, 5, 10) == 10);
-    /// }
+    /// assert!(nstd_core_math_clamp_u64(2, 5, 10) == 5);
+    /// assert!(nstd_core_math_clamp_u64(8, 5, 10) == 8);
+    /// assert!(nstd_core_math_clamp_u64(14, 5, 10) == 10);
     /// ```
     nstd_core_math_clamp_u64,
     NSTDUInt64
@@ -896,14 +824,10 @@ macro_rules! gen_div_ceil {
         /// # Panics
         ///
         /// This operation will panic if `y` is 0.
-        ///
-        /// # Safety
-        ///
-        /// This operation can cause undefined behavior if it panics into non-Rust code.
         #[inline]
         #[cfg_attr(feature = "clib", no_mangle)]
         #[allow(unused_comparisons)]
-        pub unsafe extern "C" fn $name(x: $T, y: $T) -> $T {
+        pub extern "C" fn $name(x: $T, y: $T) -> $T {
             let d = x / y;
             let r = x % y;
             if (r > 0 && y > 0) || (r < 0 && y < 0) {
@@ -932,11 +856,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_int;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_int(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_int(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_int(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_int(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_int(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_int(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_int,
     NSTDInt
@@ -959,11 +881,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_uint;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_uint(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_uint(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_uint(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_uint(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_uint(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_uint(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_uint,
     NSTDUInt
@@ -986,11 +906,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_i8;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_i8(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_i8(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_i8(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_i8(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_i8(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_i8(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_i8,
     NSTDInt8
@@ -1013,11 +931,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_u8;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_u8(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_u8(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_u8(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_u8(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_u8(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_u8(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_u8,
     NSTDUInt8
@@ -1040,11 +956,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_i16;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_i16(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_i16(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_i16(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_i16(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_i16(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_i16(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_i16,
     NSTDInt16
@@ -1067,11 +981,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_u16;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_u16(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_u16(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_u16(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_u16(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_u16(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_u16(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_u16,
     NSTDUInt16
@@ -1094,11 +1006,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_i32;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_i32(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_i32(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_i32(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_i32(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_i32(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_i32(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_i32,
     NSTDInt32
@@ -1121,11 +1031,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_u32;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_u32(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_u32(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_u32(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_u32(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_u32(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_u32(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_u32,
     NSTDUInt32
@@ -1148,11 +1056,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_i64;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_i64(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_i64(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_i64(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_i64(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_i64(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_i64(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_i64,
     NSTDInt64
@@ -1175,11 +1081,9 @@ gen_div_ceil!(
     /// ```
     /// use nstd_sys::core::math::nstd_core_math_div_ceil_u64;
     ///
-    /// unsafe {
-    ///     assert!(nstd_core_math_div_ceil_u64(8, 5) == 2);
-    ///     assert!(nstd_core_math_div_ceil_u64(8, 3) == 3);
-    ///     assert!(nstd_core_math_div_ceil_u64(8, 2) == 4);
-    /// }
+    /// assert!(nstd_core_math_div_ceil_u64(8, 5) == 2);
+    /// assert!(nstd_core_math_div_ceil_u64(8, 3) == 3);
+    /// assert!(nstd_core_math_div_ceil_u64(8, 2) == 4);
     /// ```
     nstd_core_math_div_ceil_u64,
     NSTDUInt64
@@ -1204,25 +1108,19 @@ macro_rules! gen_div_floor {
         ///
         /// This operation will panic if `y` is 0.
         ///
-        /// # Safety
-        ///
-        /// This operation can cause undefined behavior if it panics into non-Rust code.
-        ///
         /// # Example
         ///
         /// ```
         #[doc = concat!("use nstd_sys::core::math::", stringify!($name), ";")]
         ///
-        /// unsafe {
-        #[doc = concat!("    assert!(", stringify!($name), "(5, 2) == 2);")]
-        #[doc = concat!("    assert!(", stringify!($name), "(13, 4) == 3);")]
-        #[doc = concat!("    assert!(", stringify!($name), "(23, 5) == 4);")]
-        /// }
+        #[doc = concat!("assert!(", stringify!($name), "(5, 2) == 2);")]
+        #[doc = concat!("assert!(", stringify!($name), "(13, 4) == 3);")]
+        #[doc = concat!("assert!(", stringify!($name), "(23, 5) == 4);")]
         /// ```
         #[inline]
         #[cfg_attr(feature = "clib", no_mangle)]
         #[allow(unused_comparisons)]
-        pub unsafe extern "C" fn $name(x: $T, y: $T) -> $T {
+        pub extern "C" fn $name(x: $T, y: $T) -> $T {
             let d = x / y;
             let r = x % y;
             if (r > 0 && y < 0) || (r < 0 && y > 0) {

--- a/src/core/str.rs
+++ b/src/core/str.rs
@@ -34,10 +34,7 @@ macro_rules! gen_to_primitive {
         ///
         /// # Safety
         ///
-        /// - This operation can cause undefined behavior in the event that `str`'s data is
-        /// invalid.
-        ///
-        /// - This operation can cause undefined behavior if it panics into non-Rust code.
+        /// This operation can cause undefined behavior in the event that `str`'s data is invalid.
         #[inline]
         #[cfg_attr(feature = "clib", no_mangle)]
         pub unsafe extern "C" fn $name(str: &$StrT, errc: &mut NSTDErrorCode) -> $RetT {
@@ -98,9 +95,7 @@ impl NSTDStr {
 ///
 /// # Safety
 ///
-/// - `cstr`'s data must be valid for reads of at least `cstr.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// `cstr`'s data must be valid for reads of at least `cstr.len` consecutive bytes.
 ///
 /// # Example
 ///
@@ -185,10 +180,8 @@ pub unsafe extern "C" fn nstd_core_str_from_cstr_unchecked(cstr: &NSTDCStr) -> N
 ///
 /// # Safety
 ///
-/// - This function makes access to raw pointer data, which can cause undefined behavior in the
-/// event that `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This function makes access to raw pointer data, which can cause undefined behavior in the event
+/// that `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -231,10 +224,8 @@ pub unsafe extern "C" fn nstd_core_str_from_raw_cstr(cstr: *const NSTDChar) -> N
 ///
 /// # Safety
 ///
-/// - This function makes access to raw pointer data, which can cause undefined behavior in the
-/// event that `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This function makes access to raw pointer data, which can cause undefined behavior in the event
+/// that `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -283,8 +274,6 @@ pub unsafe extern "C" fn nstd_core_str_from_raw_cstr_with_null(cstr: *const NSTD
 ///
 /// - `bytes`'s data must be valid for reads of at least `bytes.len` consecutive bytes.
 ///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
@@ -330,8 +319,6 @@ pub unsafe extern "C" fn nstd_core_str_from_bytes(bytes: &NSTDSlice) -> NSTDStr 
 /// - `bytes` must remain valid while the returned string slice is in use.
 ///
 /// - `bytes`'s data must be valid for reads of at least `bytes.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
 ///
 /// # Example
 ///
@@ -420,9 +407,7 @@ pub extern "C" fn nstd_core_str_as_ptr(str: &NSTDStr) -> *const NSTDByte {
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -492,9 +477,7 @@ pub extern "C" fn nstd_core_str_byte_len(str: &NSTDStr) -> NSTDUInt {
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -544,9 +527,7 @@ pub unsafe extern "C" fn nstd_core_str_get_char(str: &NSTDStr, pos: NSTDUInt) ->
 ///
 /// # Safety
 ///
-/// - `str`'s data must be valid for reads of at least `str.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// `str`'s data must be valid for reads of at least `str.len` consecutive bytes.
 ///
 /// # Example
 ///
@@ -986,9 +967,7 @@ impl NSTDStrMut {
 ///
 /// # Safety
 ///
-/// - `cstr`'s data must be valid for reads of at least `cstr.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// `cstr`'s data must be valid for reads of at least `cstr.len` consecutive bytes.
 ///
 /// # Example
 ///
@@ -1075,10 +1054,8 @@ pub unsafe extern "C" fn nstd_core_str_mut_from_cstr_unchecked(
 ///
 /// # Safety
 ///
-/// - This function makes access to raw pointer data, which can cause undefined behavior in the
-/// event that `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This function makes access to raw pointer data, which can cause undefined behavior in the event
+/// that `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1121,10 +1098,8 @@ pub unsafe extern "C" fn nstd_core_str_mut_from_raw_cstr(cstr: *mut NSTDChar) ->
 ///
 /// # Safety
 ///
-/// - This function makes access to raw pointer data, which can cause undefined behavior in the
-/// event that `cstr`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This function makes access to raw pointer data, which can cause undefined behavior in the event
+/// that `cstr`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1177,8 +1152,6 @@ pub unsafe extern "C" fn nstd_core_str_mut_from_raw_cstr_with_null(
 ///
 /// - `bytes`'s data must be valid for reads of at least `bytes.len` consecutive bytes.
 ///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
-///
 /// # Example
 ///
 /// ```
@@ -1224,8 +1197,6 @@ pub unsafe extern "C" fn nstd_core_str_mut_from_bytes(bytes: &mut NSTDSliceMut) 
 /// - `bytes` must remain valid while the returned string slice is in use.
 ///
 /// - `bytes`'s data must be valid for reads of at least `bytes.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
 ///
 /// # Example
 ///
@@ -1335,9 +1306,7 @@ pub extern "C" fn nstd_core_str_mut_as_ptr(str: &NSTDStrMut) -> *const NSTDByte 
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1409,9 +1378,7 @@ pub extern "C" fn nstd_core_str_mut_byte_len(str: &NSTDStrMut) -> NSTDUInt {
 ///
 /// # Safety
 ///
-/// - This operation can cause undefined behavior in the event that `str`'s data is invalid.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// This operation can cause undefined behavior in the event that `str`'s data is invalid.
 ///
 /// # Example
 ///
@@ -1464,9 +1431,7 @@ pub unsafe extern "C" fn nstd_core_str_mut_get_char(
 ///
 /// # Safety
 ///
-/// - `str`'s data must be valid for reads of at least `str.len` consecutive bytes.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// `str`'s data must be valid for reads of at least `str.len` consecutive bytes.
 ///
 /// # Example
 ///

--- a/src/os/windows/alloc.rs
+++ b/src/os/windows/alloc.rs
@@ -38,9 +38,7 @@ pub enum NSTDWindowsAllocError {
 ///
 /// # Safety
 ///
-/// - See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapalloc>.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapalloc>.
 ///
 /// # Example
 ///
@@ -88,9 +86,7 @@ pub unsafe extern "C" fn nstd_os_windows_alloc_allocate(size: NSTDUInt) -> NSTDA
 ///
 /// # Safety
 ///
-/// - See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapalloc>.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapalloc>.
 ///
 /// # Example
 ///
@@ -139,9 +135,7 @@ pub unsafe extern "C" fn nstd_os_windows_alloc_allocate_zeroed(size: NSTDUInt) -
 ///
 /// # Safety
 ///
-/// - See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heaprealloc>.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heaprealloc>.
 ///
 /// # Example
 ///
@@ -193,9 +187,7 @@ pub unsafe extern "C" fn nstd_os_windows_alloc_reallocate(
 ///
 /// # Safety
 ///
-/// - See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapfree>.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapfree>.
 ///
 /// # Example
 ///

--- a/src/os/windows/alloc/heap.rs
+++ b/src/os/windows/alloc/heap.rs
@@ -23,9 +23,7 @@ pub struct NSTDWindowsHeap {
 ///
 /// # Safety
 ///
-/// - See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-getprocessheap>.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-getprocessheap>.
 ///
 /// # Example
 ///
@@ -73,9 +71,7 @@ pub unsafe extern "C" fn nstd_os_windows_alloc_heap_default() -> NSTDWindowsHeap
 ///
 /// # Safety
 ///
-/// - See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapcreate>.
-///
-/// - This operation can cause undefined behavior if it panics into non-Rust code.
+/// See <https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapcreate>.
 ///
 /// # Example
 ///


### PR DESCRIPTION
This has been done to keep functions that may panic safe, as unwinding into foreign code can cause undefined behavior.

More information can be found [here](https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html).